### PR TITLE
Allow momentjs to update to any 2.10+ version.

### DIFF
--- a/moment-hijri.js
+++ b/moment-hijri.js
@@ -301,14 +301,20 @@
 					return i
 			}
 		}
-	})
-
-	var oldLocale = moment.locale();
-	moment.defineLocale('ar-sa', {
+	});
+	var iMonthNames = {
 		iMonths: 'محرم_صفر_ربيع الأول_ربيع الثاني_جمادى الأولى_جمادى الآخرة_رجب_شعبان_رمضان_شوال_ذو القعدة_ذو الحجة'.split('_'),
 		iMonthsShort: 'محرم_صفر_ربيع ١_ربيع ٢_جمادى ١_جمادى ٢_رجب_شعبان_رمضان_شوال_ذو القعدة_ذو الحجة'.split('_')
-	});
-	moment.locale(oldLocale);
+	};
+
+	// Default to the momentjs 2.12+ API
+	if (typeof moment.updateLocale === 'function') {
+		moment.updateLocale('ar-sa', iMonthNames);
+	} else {
+		var oldLocale = moment.locale();
+		moment.defineLocale('ar-sa', iMonthNames);
+		moment.locale(oldLocale);
+	}
 	
 	/************************************
       Formatting

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "bower": "~1.2.6"
   },
   "dependencies": {
-    "moment": "~2.10.3"
+    "moment": "^2.10.3"
   },
   "jshintConfig": {
     "camelcase": true,


### PR DESCRIPTION
This allows for consumers to pick up new versions of moment and moment-tz without unnecessarily duplicating moment.js in the dependency tree.

Tests and lint pass locally - let me know if I can do anything further to assist!