### PR TITLE
adds _abbr so that date.locale() won't be undefined

### DIFF
--- a/moment-hijri.js
+++ b/moment-hijri.js
@@ -250,6 +250,7 @@
       Languages
   ************************************/
 	extend(getPrototypeOf(moment.localeData()), {
+		_abbr: "ar-sa",
 		_iMonths: ['Muharram'
                 , 'Safar'
                 , 'Rabi\' al-Awwal'


### PR DESCRIPTION
reloves antd DatePicker issue of undefined doesn't have function
utcOffset

ref #43