### PR TITLE
require moment/moment to fix moment.localeData is not a function error in vite

### DIFF
--- a/moment-hijri.js
+++ b/moment-hijri.js
@@ -16,7 +16,7 @@
 			return root.moment
 		})
 	} else if (typeof exports === 'object') {
-		module.exports = factory(require('moment'))
+		module.exports = factory(require('moment/moment'))
 	} else {
 		root.moment = factory(root.moment)
 	}


### PR DESCRIPTION
require moment/moment to fix moment.localeData is not a function error in vite