### PR TITLE
Update day count for month 5 and 6

### DIFF
--- a/moment-hijri.js
+++ b/moment-hijri.js
@@ -175,6 +175,12 @@
 		}
 	}, i
 
+	// Adjustment of the day count for month(5) and month(6) months for the year (1446) as per Umm al-Qura Calendar.
+	// Updated month(5) to have 29 days and month(6) to have 30 days.
+	let indexOfMonth_5 = getNewMoonMJDNIndex(1446, 5);
+	console.log(indexOfMonth_5);
+	ummalqura.ummalquraData[indexOfMonth_5] -= 1;
+
 	function padToken(func, count) {
 		return function (a) {
 			return leftZeroFill(func.call(this, a), count)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moment-hijri",
-  "version": "2.1.2",
+  "version": "2.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "moment-hijri",
-      "version": "2.1.2",
+      "version": "2.30.0",
       "license": "MIT",
       "dependencies": {
         "moment": "^2.30.1"


### PR DESCRIPTION
Adjusted the number of days for the Hijri months of Jumada al-awwal (5) to 29 days and Jumada al-akhir (6) to 30 days, in accordance with the Umm al-Qura calendar for the year 1446.