### PR TITLE
fix(parse): map Hijri month names to correct 0-based indices

### DIFF
--- a/moment-hijri.js
+++ b/moment-hijri.js
@@ -354,14 +354,13 @@
 
 		,
 		iMonthsParse: function (monthName) {
-			var i, mom, regex
+			var i, regex
 			if (!this._iMonthsParse)
 				this._iMonthsParse = []
 			for (i = 0; i < 12; i += 1) {
 				// Make the regex if we don't have it already.
 				if (!this._iMonthsParse[i]) {
-					mom = hMoment([2000, (2 + i) % 12, 25])
-					regex = '^' + this.iMonths(mom, '') + '$|^' + this.iMonthsShort(mom, '') + '$'
+					regex = '^' + this._iMonths[i] + '$|^' + this._iMonthsShort[i] + '$'
 					this._iMonthsParse[i] = new RegExp(regex.replace('.', ''), 'i')
 				}
 				// Test the regex.
@@ -727,10 +726,10 @@
 		var lastDay, h, g
 		if (input != null) {
 			if (typeof input === 'string') {
+				// iMonthsParse returns a 0-based month index, matching the
+				// numeric input convention used below (see #60).
 				input = this.localeData().iMonthsParse(input)
-				if(input >= 0) {
-					input -= 1
-				} else {
+				if (input == null || input < 0) {
 					return this
 				}
 			}

--- a/test.js
+++ b/test.js
@@ -91,6 +91,21 @@ describe('moment', function() {
       m = moment('60 5 30', ['iYY iM iD', 'YY M D'])
       m.format('iYY-iMM-iDD').should.be.equal('60-05-30')
     })
+
+    it('should round-trip Hijri month names without shifting months', function() {
+      // Regression test for #60: iMonthsParse mapped names to the wrong
+      // indices, so parsing '22 Shw 1440' came back a month later.
+      var input = '22 Shw 1440'
+        , output = moment(input, 'iDD iMMM iYYYY').format('iDD iMMM iYYYY')
+      output.should.be.equal(input)
+      // Hyphenated abbreviations (Rab-I, Dhu-Q, ...) are excluded: the word
+      // tokenizer splits on '-', which predates this fix.
+      var months = ['Muh', 'Saf', 'Raj', 'Sha', 'Ram', 'Shw']
+        , expected = ['01', '02', '07', '08', '09', '10']
+      months.forEach(function (name, index) {
+        moment('15 ' + name + ' 1440', 'iDD iMMM iYYYY').format('iMM').should.be.equal(expected[index])
+      })
+    })
   })
 
   describe('#format', function() {


### PR DESCRIPTION
## Summary

Fixes Hijri month-name parsing being off by (an arbitrary) month: `moment('22 Shw 1440',
'iDD iMMM iYYYY')` came back as `22 Dhu-Q 1440`.

Fixes #60

## Root cause (two compensating bugs)

1. `iMonthsParse` built each month-name regex from a Gregorian probe date
   (`hMoment([2000, (2 + i) % 12, 25])`) whose Hijri month is arbitrary — so names mapped to
   whatever indices those probe dates happened to fall in. It now indexes the known
   `_iMonths`/`_iMonthsShort` lists directly (same 0-based contract, same caching).
2. The `iMonth` setter subtracted 1 from the parse result, treating it as 1-based. That
   off-by-one happened to compensate the scrambled mapping for some names (e.g. the existing
   `iMonth('Shawwal')` test passed for the wrong reason), so it is removed; an unparseable
   name still leaves the moment untouched.

## Tests

- New round-trip regression test: the exact issue case plus all non-hyphenated abbreviations.
- Full `grunt test` (jshint + mocha): green, including the pre-existing
  `should set month by name and short name` test, which now passes for the right reason.

## Known limitation (not expanded here)

Hyphenated abbreviations (`Rab-I`, `Dhu-Q`, …) still fall back to month 1 — the word tokenizer
splits on `-` before the name lookup runs. That predates this fix, affects old and new code
identically, and belongs to the tokenizer, so I left it for a follow-up.
