### PR TITLE
fix(parse): delegate non-string inputs to moment core

### DIFF
--- a/moment-hijri.js
+++ b/moment-hijri.js
@@ -648,7 +648,7 @@
 		if (format) {
 			if (isArray(format)) {
 				return makeDateFromStringAndArray(config, utc)
-			} else {
+			} else if (typeof config._i === 'string') {
 				date = makeDateFromStringAndFormat(config)
 				removeParsedTokens(config)
 				format = 'YYYY-MM-DD-' + config._f
@@ -657,6 +657,8 @@
 					+ leftZeroFill(date[2], 2) + '-'
 					+ config._i
 			}
+			// Non-string input (moment, Date, ...): nothing string-like to
+			// parse, so fall through and let moment core handle it (#56, #14).
 		}
 		if (utc)
 			m = moment.utc(input, format, lang)

--- a/test.js
+++ b/test.js
@@ -58,6 +58,17 @@ describe('moment', function() {
       moment(m.format(f), f).isSame(m).should.be.true
     })
 
+    it('should accept non-string input alongside a format without crashing', function() {
+      // Regression tests for #56 (moment object) and #14 (Date object):
+      // makeMoment used to feed any input through the string parser.
+      var m = moment(moment('2020-05-16'), 'YYYY-MM-DD')
+      m.format('YYYY-MM-DD').should.be.equal('2020-05-16')
+      m.format('iYYYY/iM/iD').should.be.equal('1441/9/23')
+      var d = moment(new Date(2020, 4, 16), 'iYYYY-iMM-iDD')
+      d.format('YYYY-MM-DD').should.be.equal('2020-05-16')
+      d.format('iYYYY/iM/iD').should.be.equal('1441/9/23')
+    })
+
     it('should be able to parse in utc', function() {
       var m = moment.utc('1436/8/20 07:10:20', 'iYYYY/iM/iD hh:mm:ss')
       m.format('YYYY-MM-DD hh:mm:ss Z').should.be.equal('2015-06-07 07:10:20 +00:00')


### PR DESCRIPTION
## Summary

Passing a moment/Date object together with a format string crashed with
`TypeError: string.indexOf is not a function`, because `makeMoment` fed every input through
the string parser whenever a format was present.

Fixes #56, fixes #14

## Changes

- `moment-hijri.js` (`makeMoment`): only string inputs take the `makeDateFromStringAndFormat`
  path; non-string inputs (moment, Date, …) fall through to moment core, which already knows how
  to handle them. One `typeof` guard, no behavior change for string inputs.
- `test.js`: regression test covering both reports — a moment object with a Gregorian format
  and a `Date` object with a Hijri format.

## Verification

- Both repros crashed before the fix and convert correctly after
  (`2020-05-16` ↔ `1441/9/23`).
- Full `grunt test` (jshint + mocha): green.
